### PR TITLE
Add ParseSchema element to Schema enumeration.

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -3,8 +3,8 @@
     {
       "name": "thx.core",
       "type": "git",
-      "ref": "8e018dea",
-      "url": "git@github.com:fponticelli/thx.core"
+      "ref": "4eb62e75",
+      "url": "git@github.com:nuttycom/thx.core"
     },
     {
       "name": "utest",

--- a/src/thx/schema/Schema.hx
+++ b/src/thx/schema/Schema.hx
@@ -1,58 +1,65 @@
 package thx.schema;
 
 import haxe.ds.Option;
-import haxe.ds.StringMap;
-import thx.Unit;
 
 /**
  * A GADT describing the elements of a JSON-compatible Haxe object schema.
  * Generally, you shouldn't use the constructors of this type
  * directly, but instead use those provided as convenience methods in SchemaDSL.
  */
-enum Schema<A> {
-  BoolSchema: Schema<Bool>;
-  FloatSchema: Schema<Float>;
-  IntSchema: Schema<Int>;
-  StrSchema: Schema<String>;
-  UnitSchema: Schema<Unit>;
+enum Schema<A, E> {
+  BoolSchema:  Schema<Bool, E>;
+  FloatSchema: Schema<Float, E>;
+  IntSchema:   Schema<Int, E>;
+  StrSchema:   Schema<String, E>;
 
-  ObjectSchema<B>(propSchema: ObjectBuilder<B, B>): Schema<B>;
-  ArraySchema<B>(elemSchema: Schema<B>): Schema<Array<B>>;
-  MapSchema<B>(elemSchema: Schema<B>): Schema<Map<String, B>>; // interpret as a String-keyed map instead of an object value
+  ObjectSchema<B>(propSchema: ObjectBuilder<B, B, E>): Schema<B, E>;
+  ArraySchema<B>(elemSchema: Schema<B, E>): Schema<Array<B>, E>;
+  MapSchema<B>(elemSchema: Schema<B, E>): Schema<Map<String, B>, E>; // interpret as a String-keyed map instead of an object value
 
   // schema for sum types
-  OneOfSchema<B>(alternatives: Array<Alternative<B>>): Schema<B>;
+  OneOfSchema<B>(alternatives: Array<Alternative<B, E>>): Schema<B, E>;
 
-  // This allows us to create schemas that parse to newtype wrappers
-  IsoSchema<B, C>(base: Schema<B>, f: B -> C, g: C -> B): Schema<C>;
+  // This allows us to create schemas that impose more constraints on
+  // the type of source data than merely being isomorphic to a primitive
+  // value type.
+  ParseSchema<B, C>(base: Schema<B, E>, f: B -> ParseResult<B, C, E>, g: C -> B): Schema<C, E>;
+
+  // Schema that always parses to or generates a constant value. 
+  ConstSchema<B>(value: B): Schema<B, E>;
 
   // Lazy wrapper for schema values to permit recursive schema definitions.
-  LazySchema<B>(delay: Void -> Schema<B>): Schema<B>;
+  LazySchema<B>(delay: Void -> Schema<B, E>): Schema<B, E>;
 }
 
-enum Alternative<A> {
-  Prism<A, B>(id: String, base: Schema<B>, f: B -> A, g: A -> Option<B>): Alternative<A>;
+enum ParseResult<S, A, E> {
+  PSuccess(result: A);
+  PFailure(error: E, sourceData: S);
 }
 
-enum PropSchema<O, A> {
-  Required<B>(fieldName: String, valueSchema: Schema<B>, accessor: O -> B): PropSchema<O, B>;
-  Optional<B>(fieldName: String, valueSchema: Schema<B>, accessor: O -> Option<B>): PropSchema<O, Option<B>>;
+enum Alternative<A, E> {
+  Prism<A, B>(id: String, base: Schema<B, E>, f: B -> A, g: A -> Option<B>): Alternative<A, E>;
+}
+
+enum PropSchema<O, A, E> {
+  Required<B>(fieldName: String, valueSchema: Schema<B, E>, accessor: O -> B): PropSchema<O, B, E>;
+  Optional<B>(fieldName: String, valueSchema: Schema<B, E>, accessor: O -> Option<B>): PropSchema<O, Option<B>, E>;
 }
 
 /** Free applicative construction of builder for a set of object properties. */
-enum ObjectBuilder<O, A> {
+enum ObjectBuilder<O, A, E> {
   Pure(a: A);
-  Ap<I>(s: PropSchema<O, I>, k: ObjectBuilder<O, I -> A>);
+  Ap<I>(s: PropSchema<O, I, E>, k: ObjectBuilder<O, I -> A, E>);
 }
 
-typedef HomObjectBuilder<A> = ObjectBuilder<A, A>;
+typedef HomObjectBuilder<A, E> = ObjectBuilder<A, A, E>;
 
 enum SType {
   BoolSType;
   FloatSType;
   IntSType;
   StrSType;
-  UnitSType;
+  ConstSType;
   ObjectSType;
   ArraySType;
   MapSType;

--- a/src/thx/schema/SchemaDSL.hx
+++ b/src/thx/schema/SchemaDSL.hx
@@ -12,56 +12,58 @@ import thx.schema.Schema;
 using thx.schema.SchemaExtensions;
 
 class SchemaDSL {
-  public static function lift<O, A>(s: PropSchema<O, A>): ObjectBuilder<O, A>
+  public static function lift<O, A, E>(s: PropSchema<O, A, E>): ObjectBuilder<O, A, E>
     return Ap(s, Pure(function(a: A) return a));
 
   //
   // Constructors for terminal schema elements
   //
 
-  public static var bool(default, never): Schema<Bool> = BoolSchema;
-  public static var float(default, never): Schema<Float> = FloatSchema;
-  public static var int(default, never): Schema<Int> = IntSchema;
-  public static var string(default, never): Schema<String> = StrSchema;
+  public static function bool<E>():   Schema<Bool, E>   return BoolSchema;
+  public static function float<E>():  Schema<Float, E>  return FloatSchema;
+  public static function int<E>():    Schema<Int, E>    return IntSchema;
+  public static function string<E>(): Schema<String, E> return StrSchema;
 
-  public static function array<A>(elemSchema: Schema<A>): Schema<Array<A>>
+  public static function array<A, E>(elemSchema: Schema<A, E>): Schema<Array<A>, E>
     return ArraySchema(elemSchema);
 
-  public static function map<A>(elemSchema: Schema<A>): Schema<Map<String, A>>
+  public static function map<A, E>(elemSchema: Schema<A, E>): Schema<Map<String, A>, E>
     return MapSchema(elemSchema);
 
-  public static function object<A>(propSchema: ObjectBuilder<A, A>): Schema<A>
+  public static function object<A, E>(propSchema: ObjectBuilder<A, A, E>): Schema<A, E>
     return ObjectSchema(propSchema);
 
-  public static function oneOf<A>(alternatives: Array<Alternative<A>>): Schema<A>
+  public static function oneOf<A, E>(alternatives: Array<Alternative<A, E>>): Schema<A, E>
     return OneOfSchema(alternatives);
 
-  public static function iso<A, B>(base: Schema<A>, f: A -> B, g: B -> A): Schema<B>
-    return IsoSchema(base, f, g);
+  public static function iso<A, B, E>(base: Schema<A, E>, f: A -> B, g: B -> A): Schema<B, E>
+    return ParseSchema(base, function(a: A) return PSuccess(f(a)), g);
 
-  public static function lazy<A>(base: Void -> Schema<A>): Schema<A>
+  public static function parse<A, B, E>(base: Schema<A, E>, f: A -> ParseResult<A, B, E>, g: B -> A): Schema<B, E>
+    return ParseSchema(base, f, g);
+
+  public static function lazy<A, E>(base: Void -> Schema<A, E>): Schema<A, E>
     return LazySchema(base);
 
-  public static function constant<A>(a: A): Schema<A>
-    return iso(UnitSchema, const(a), const(unit));
+  public static function constant<A, E>(a: A): Schema<A, E>
+    return ConstSchema(a);
 
   //
   // Constructors for oneOf alternatives
   //
-
-  public static function alt<A, B>(id: String, base: Schema<B>, f: B -> A, g: A -> Option<B>): Alternative<A>
+  public static function alt<A, B, E>(id: String, base: Schema<B, E>, f: B -> A, g: A -> Option<B>): Alternative<A, E>
     return Prism(id, base, f, g);
 
-  public static function constAlt<B>(id: String, b: B, equal: B -> B -> Bool): Alternative<B>
+  public static function constAlt<B, E>(id: String, b: B, equal: B -> B -> Bool): Alternative<B, E>
     return Prism(id, constant(b), identity, function(b0) return equal(b, b0).option(b));
 
-  public static function constEnum<B : EnumValue>(id: String, b: B): Alternative<B>
+  public static function constEnum<B : EnumValue, E>(id: String, b: B): Alternative<B, E>
     return constAlt(id, b, Type.enumEq);
 
   macro public static function makeAlt(id: haxe.macro.Expr.ExprOf<String>, rest: Array<haxe.macro.Expr>)
     return SchemaDSLM.makeVar(id, rest);
 
-  public static function makeOptional<A>(s: Schema<A>): Schema<Option<A>>
+  public static function makeOptional<A, E>(s: Schema<A, E>): Schema<Option<A>, E>
     return oneOf([
       alt("some", s, function(a: A) return Some(a), thx.Functions.identity),
       constAlt("none", None, function(a: Option<A>, b: Option<A>) return a == b)
@@ -71,65 +73,65 @@ class SchemaDSL {
   // Constructors for object properties.
   //
 
-  public static function required<O, A>(fieldName: String, valueSchema: Schema<A>, accessor: O -> A): ObjectBuilder<O, A>
+  public static function required<O, A, E>(fieldName: String, valueSchema: Schema<A, E>, accessor: O -> A): ObjectBuilder<O, A, E>
     return lift(Required(fieldName, valueSchema, accessor));
 
-  public static function optional<O, A>(fieldName: String, valueSchema: Schema<A>, accessor: O -> Option<A>): ObjectBuilder<O, Option<A>>
+  public static function optional<O, A, E>(fieldName: String, valueSchema: Schema<A, E>, accessor: O -> Option<A>): ObjectBuilder<O, Option<A>, E>
     return lift(Optional(fieldName, valueSchema, accessor));
 
   // Convenience constructor for a single-property object schema that simply wraps another schema.
-  public static function wrap<A>(fieldName: String, valueSchema: Schema<A>): Schema<A>
+  public static function wrap<A, E>(fieldName: String, valueSchema: Schema<A, E>): Schema<A, E>
     return object(required(fieldName, valueSchema, identity));
 
   //
   // Combinators for building complex schemas
   //
-  inline static public function ap1<O, X, A, B>(
+  inline static public function ap1<O, E, A, B>(
       f: A -> B,
-      v1: ObjectBuilder<O, A>): ObjectBuilder<O, B>
+      v1: ObjectBuilder<O, A, E>): ObjectBuilder<O, B, E>
     return v1.map(f);
 
-  inline static public function ap2<O, X, A, B, C>(
+  inline static public function ap2<O, E, A, B, C>(
       f: A -> B -> C,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>): ObjectBuilder<O, C>
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>): ObjectBuilder<O, C, E>
     return v2.ap(v1.map(Functions2.curry(f)));
 
-  inline static public function ap3<O, X, A, B, C, D>(
+  inline static public function ap3<O, E, A, B, C, D>(
       f: A -> B -> C -> D,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>): ObjectBuilder<O, D>
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>): ObjectBuilder<O, D, E>
     return v3.ap(ap2(Functions3.curry(f), v1, v2));
 
-  inline static public function ap4<O, X, A, B, C, D, E>(
-      f: A -> B -> C -> D -> E,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>, v4: ObjectBuilder<O, D>): ObjectBuilder<O, E>
+  inline static public function ap4<O, E, A, B, C, D, F>(
+      f: A -> B -> C -> D -> F,
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>, v4: ObjectBuilder<O, D, E>): ObjectBuilder<O, F, E>
     return v4.ap(ap3(Functions4.curry(f), v1, v2, v3));
 
-  inline static public function ap5<O, X, A, B, C, D, E, F>(
-      f: A -> B -> C -> D -> E -> F,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>, v4: ObjectBuilder<O, D>, v5: ObjectBuilder<O, E>): ObjectBuilder<O, F>
+  inline static public function ap5<O, E, A, B, C, D, F, G>(
+      f: A -> B -> C -> D -> F -> G,
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>, v4: ObjectBuilder<O, D, E>, v5: ObjectBuilder<O, F, E>): ObjectBuilder<O, G, E>
     return v5.ap(ap4(Functions5.curry(f), v1, v2, v3, v4));
 
-  inline static public function ap6<O, X, A, B, C, D, E, F, G>(
-      f: A -> B -> C -> D -> E -> F -> G,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>, v4: ObjectBuilder<O, D>, v5: ObjectBuilder<O, E>,
-      v6: ObjectBuilder<O, F>): ObjectBuilder<O, G>
+  inline static public function ap6<O, E, A, B, C, D, F, G, H>(
+      f: A -> B -> C -> D -> F -> G -> H,
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>, v4: ObjectBuilder<O, D, E>, v5: ObjectBuilder<O, F, E>,
+      v6: ObjectBuilder<O, G, E>): ObjectBuilder<O, H, E>
     return v6.ap(ap5(Functions6.curry(f), v1, v2, v3, v4, v5));
 
-  inline static public function ap7<O, X, A, B, C, D, E, F, G, H>(
-      f: A -> B -> C -> D -> E -> F -> G -> H,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>, v4: ObjectBuilder<O, D>, v5: ObjectBuilder<O, E>,
-      v6: ObjectBuilder<O, F>, v7: ObjectBuilder<O, G>): ObjectBuilder<O, H>
+  inline static public function ap7<O, E, A, B, C, D, F, G, H, I>(
+      f: A -> B -> C -> D -> F -> G -> H -> I,
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>, v4: ObjectBuilder<O, D, E>, v5: ObjectBuilder<O, F, E>,
+      v6: ObjectBuilder<O, G, E>, v7: ObjectBuilder<O, H, E>): ObjectBuilder<O, I, E>
     return v7.ap(ap6(Functions7.curry(f), v1, v2, v3, v4, v5, v6));
 
-  inline static public function ap8<O, X, A, B, C, D, E, F, G, H, I>(
-      f: A -> B -> C -> D -> E -> F -> G -> H -> I,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>, v4: ObjectBuilder<O, D>, v5: ObjectBuilder<O, E>,
-      v6: ObjectBuilder<O, F>, v7: ObjectBuilder<O, G>, v8: ObjectBuilder<O, H>): ObjectBuilder<O, I>
+  inline static public function ap8<O, E, A, B, C, D, F, G, H, I, J>(
+      f: A -> B -> C -> D -> F -> G -> H -> I -> J,
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>, v4: ObjectBuilder<O, D, E>, v5: ObjectBuilder<O, F, E>,
+      v6: ObjectBuilder<O, G, E>, v7: ObjectBuilder<O, H, E>, v8: ObjectBuilder<O, I, E>): ObjectBuilder<O, J, E>
     return v8.ap(ap7(Functions8.curry(f), v1, v2, v3, v4, v5, v6, v7));
 
-  inline static public function ap9<O, X, A, B, C, D, E, F, G, H, I, J>(
-      f: A -> B -> C -> D -> E -> F -> G -> H -> I -> J,
-      v1: ObjectBuilder<O, A>, v2: ObjectBuilder<O, B>, v3: ObjectBuilder<O, C>, v4: ObjectBuilder<O, D>, v5: ObjectBuilder<O, E>,
-      v6: ObjectBuilder<O, F>, v7: ObjectBuilder<O, G>, v8: ObjectBuilder<O, H>, v9: ObjectBuilder<O, I>): ObjectBuilder<O, J>
+  inline static public function ap9<O, E, A, B, C, D, F, G, H, I, J, K>(
+      f: A -> B -> C -> D -> F -> G -> H -> I -> J -> K,
+      v1: ObjectBuilder<O, A, E>, v2: ObjectBuilder<O, B, E>, v3: ObjectBuilder<O, C, E>, v4: ObjectBuilder<O, D, E>, v5: ObjectBuilder<O, F, E>,
+      v6: ObjectBuilder<O, G, E>, v7: ObjectBuilder<O, H, E>, v8: ObjectBuilder<O, I, E>, v9: ObjectBuilder<O, J, E>): ObjectBuilder<O, K, E>
     return v9.ap(ap8(Functions9.curry(f), v1, v2, v3, v4, v5, v6, v7, v8));
 }

--- a/src/thx/schema/SchemaDSLM.hx
+++ b/src/thx/schema/SchemaDSLM.hx
@@ -35,7 +35,7 @@ class SchemaDSLM {
     return macro thx.schema.SchemaDSL.alt($id, $sub, $constr, $f);
   }
 
-  public static function make(id: ExprOf<String>, constr: Expr, extr: Expr, obj: ExprOf<Dynamic<Schema<Dynamic>>>) {
+  public static function make<E>(id: ExprOf<String>, constr: Expr, extr: Expr, obj: ExprOf<Dynamic<Schema<Dynamic, E>>>) {
     var valueType = getValueType(constr);
     var fields = getFields(obj);
     var objectType = getObjectType(fields);
@@ -54,7 +54,7 @@ class SchemaDSLM {
 
   static function isSchema(e: Expr) {
     return switch Context.typeof(e) {
-      case TEnum(_, [type]): true; // TODO make the match stricter
+      case TEnum(_, [type, _]): true; // TODO make the match stricter
       case _: false;
     };
   }
@@ -69,7 +69,8 @@ class SchemaDSLM {
     }
     return fieldData.map(function(field) {
       var t = switch Context.typeof(field.expr) {
-        case TEnum(_, [type]): type; // TODO make the match stricter
+        case TEnum(_, [type, _]): type; // TODO make the match stricter
+        case TFun(_, TEnum(_, [type, _])): type;
         case _: Context.error('invalid schema type for `{$field.field}` [found ${field.expr}]', Context.currentPos());
       }
       return {

--- a/src/thx/schema/SchemaExtensions.hx
+++ b/src/thx/schema/SchemaExtensions.hx
@@ -16,76 +16,113 @@ import thx.schema.Schema;
  * to be imported via 'using'.
  */
 class SchemaExtensions {
-  public static function id<A>(a: Alternative<A>)
+  public static function id<A, E>(a: Alternative<A, E>)
     return switch a {
       case Prism(id, _, _, _): id;
     };
 
-  public static function stype<A>(schema: Schema<A>): SType
+  public static function stype<A, E>(schema: Schema<A, E>): SType
     return switch schema {
       case BoolSchema:  BoolSType;
       case FloatSchema: FloatSType;
       case IntSchema:   IntSType;
       case StrSchema:   StrSType;
-      case UnitSchema:  UnitSType;
-      case ObjectSchema(propSchema): ObjectSType;
-      case ArraySchema(elemSchema):  ArraySType;
-      case MapSchema(elemSchema):    MapSType;
+      case ConstSchema(_):  ConstSType;
+      case ObjectSchema(propSchema):  ObjectSType;
+      case ArraySchema(elemSchema):   ArraySType;
+      case MapSchema(elemSchema):     MapSType;
       case OneOfSchema(alternatives): OneOfSType;
-      case IsoSchema(base, f, g): stype(base);
+      case ParseSchema(base, f, g): stype(base);
       case LazySchema(base): stype(base());
     };
 
-  public static function isConstant<A>(schema: Schema<A>): Bool
+  public static function isConstant<A, E>(schema: Schema<A, E>): Bool
     return switch schema {
-      case UnitSchema: true;
-      case IsoSchema(s0, _, _): isConstant(s0);
+      case ConstSchema(_): true;
+      case ParseSchema(s0, _, _): isConstant(s0);
       case LazySchema(fs): isConstant(fs());
       case _: false;
     };
+
+  public static function mapError<A, E, F>(schema: Schema<A, E>, e: E -> F): Schema<A, F> {
+    return switch schema {
+      case BoolSchema:  BoolSchema;
+      case FloatSchema: FloatSchema;
+      case IntSchema:   IntSchema;
+      case StrSchema:   StrSchema;
+      case ConstSchema(a):  ConstSchema(a);
+      case ObjectSchema(propSchema):  ObjectSchema(ObjectSchemaExtensions.mapError(propSchema, e));
+      case ArraySchema(elemSchema):   ArraySchema(mapError(elemSchema, e));
+      case MapSchema(elemSchema):     MapSchema(mapError(elemSchema, e));
+      case OneOfSchema(alternatives): OneOfSchema(alternatives.map(AlternativeExtensions.mapError.bind(_, e)));
+      case ParseSchema(base, f, g):   
+        ParseSchema(
+          mapError(base, e), 
+          function(b) return switch f(b) {
+            case PSuccess(result): PSuccess(result);
+            case PFailure(error, sourceData): PFailure(e(error), sourceData);
+          },
+          g
+        );
+      case LazySchema(base): 
+        LazySchema(function() return mapError(base(), e));
+    };
+  }
 }
 
 class ObjectSchemaExtensions {
-  public static function contramap<N, O, A>(o: ObjectBuilder<O, A>, f: N -> O): ObjectBuilder<N, A> {
+  public static function contramap<N, O, A, E>(o: ObjectBuilder<O, A, E>, f: N -> O): ObjectBuilder<N, A, E>
     return switch o {
       case Pure(a): Pure(a);
       case Ap(s, k): Ap(PropSchemaExtensions.contramap(s, f), contramap(k, f));
     }
-  }
 
-  public static function map<O, A, B>(o: ObjectBuilder<O, A>, f: A -> B): ObjectBuilder<O, B> {
+  public static function map<O, A, B, E>(o: ObjectBuilder<O, A, E>, f: A -> B): ObjectBuilder<O, B, E>
     return switch o {
       case Pure(a): Pure(f(a));
       case Ap(s, k): Ap(s, map(k, f.compose));
     };
-  }
 
-  public static function ap<O, A, B>(o: ObjectBuilder<O, A>, f: ObjectBuilder<O, A -> B>): ObjectBuilder<O, B> {
+  public static function ap<O, A, B, E>(o: ObjectBuilder<O, A, E>, f: ObjectBuilder<O, A -> B, E>): ObjectBuilder<O, B, E>
     return switch f {
       case Pure(g): map(o, g);
       case Ap(s, k): Ap(s, ap(o, map(k, flip)));
     };
-  }
+
+  public static function mapError<O, A, E, F>(o: ObjectBuilder<O, A, E>, e: E -> F): ObjectBuilder<O, A, F>
+    return switch o {
+      case Pure(g): Pure(g);
+      case Ap(s, k): Ap(PropSchemaExtensions.mapError(s, e), mapError(k, e));
+    };
 }
 
 class PropSchemaExtensions {
-  public static function contramap<N, O, A>(s: PropSchema<O, A>, f: N -> O): PropSchema<N, A>
+  public static function contramap<N, O, A, E>(s: PropSchema<O, A, E>, f: N -> O): PropSchema<N, A, E>
     return switch s {
       case Required(n, s, a): Required(n, s, a.compose(f));
       case Optional(n, s, a): Optional(n, s, a.compose(f));
     };
+
+  public static function mapError<O, A, E, F>(s: PropSchema<O, A, E>, e: E -> F): PropSchema<O, A, F>
+    return switch s {
+      case Required(n, s, a): Required(n, SchemaExtensions.mapError(s, e), a);
+      case Optional(n, s, a): Optional(n, SchemaExtensions.mapError(s, e), a);
+    }
 }
 
 class AlternativeExtensions {
-  public static function id<A>(alt: Alternative<A>): String {
+  public static function id<A, E>(alt: Alternative<A, E>): String
     return switch alt {
       case Prism(id, _, _, _): id;
     };
-  }
 
-  public static function isConstantAlt<A>(alt: Alternative<A>): Bool {
+  public static function isConstantAlt<A, E>(alt: Alternative<A, E>): Bool
     return switch alt {
       case Prism(_, s, _, _): SchemaExtensions.isConstant(s);
     };
-  }
+
+  public static function mapError<A, E, F>(alt: Alternative<A, E>, e: E -> F): Alternative<A, F> 
+    return switch alt {
+      case Prism(id, s, f, g): Prism(id, SchemaExtensions.mapError(s, e), f, g);
+    };
 }

--- a/test/thx/schema/TestSchemaDynamicExtensions.hx
+++ b/test/thx/schema/TestSchemaDynamicExtensions.hx
@@ -19,8 +19,8 @@ class TestSchemaDynamicExtensions {
 
   public function testRenderDynamic() {
     var ex: TEnum = EX(new TSimple(3));
-    var rendered = TEnums.schema.renderDynamic(ex);
-    var parsed = TEnums.schema.parse(rendered);
+    var rendered = TEnums.schema().renderDynamic(ex);
+    var parsed = TEnums.schema().parse(function(s: String) return s, rendered);
     Assert.same(Right(ex), parsed);
   }
 }

--- a/test/thx/schema/TestSchemaGenExtensions.hx
+++ b/test/thx/schema/TestSchemaGenExtensions.hx
@@ -19,7 +19,7 @@ class TestSchemaGenExtensions {
 
   public function testGen() {
     var ex: TEnum = EX(new TSimple(0));
-    var exemplar = TEnums.schema.exemplar();
+    var exemplar = TEnums.schema().exemplar();
     Assert.same(ex, exemplar);
   }
 }


### PR DESCRIPTION
This adds the ability to perform arbitrary parsing and/or validation
in the process of evaluation of a schema. Because this introduces a
failure case that must be known at the time of schema construction,
it adds an error type parameter to the schema. In order to preserve
the contract for automatic exemplar generation, we use an uninhabited
type as the value of this parameter when passing schema to the
'generate' function.

Review by @fponticelli 